### PR TITLE
Use mod.conf instead of depends.txt and description.txt

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,0 @@
-default
-farming

--- a/description.txt
+++ b/description.txt
@@ -1,1 +1,0 @@
-Adds customisable banners.

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,3 @@
+name = banners
+description = Adds customisable banners.
+depends = default,farming


### PR DESCRIPTION
Fixes warnings that appear from 5.5 or higher